### PR TITLE
Fix to allow text input in web components.

### DIFF
--- a/type-ahead.js
+++ b/type-ahead.js
@@ -164,6 +164,8 @@ function isInputElementActive(doc) {
   var name = element.tagName.toLowerCase();
   if (["input", "select", "textarea", "object", "embed"].indexOf(name) >= 0)
     return true;
+  if (name.match(/-/)) // Web Components
+    return true;
   return (upMatch(element, function(el) {
       if (!el.getAttribute || el.getAttribute('contenteditable') == 'false')
         return null;


### PR DESCRIPTION
Without this, the extension will perform a search instead of allowing input. To see this in action, try the following:
* The search input here: http://www.twelvetone.tv/iron-icons-search/index.html
* The email input here: https://vaadin.com/components/vaadin-email-field/html-examples/email-field-demos
* Combo box text input: https://vaadin.com/components/vaadin-combo-box/html-examples
* Any other text input inside a web component. 

There may be a better way to allow text input inside web components, but this small change seems to fix the problem without breaking anything else (at least in my own usage so far).